### PR TITLE
修改.service配置

### DIFF
--- a/v2ray-linux-amd64/etc/systemd/system/v2ray.service
+++ b/v2ray-linux-amd64/etc/systemd/system/v2ray.service
@@ -11,6 +11,8 @@ NoNewPrivileges=true
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
 Restart=on-failure
 RestartPreventExitStatus=23
+RestartSec=5
+LogsDirectory=v2ray
 
 [Install]
 WantedBy=multi-user.target

--- a/v2ray-linux-amd64/etc/v2ray/server.json
+++ b/v2ray-linux-amd64/etc/v2ray/server.json
@@ -4,10 +4,10 @@
 {
   "log": {
     // By default, V2Ray writes access log to stdout.
-    // "access": "/path/to/access/log/file",
+    // "access": "/var/log/v2ray/access.log",
 
     // By default, V2Ray write error log to stdout.
-    // "error": "/path/to/error/log/file",
+    // "error": "/var/log/v2ray/error.log",
 
     // Log level, one of "debug", "info", "warning", "error", "none"
     "loglevel": "warning"


### PR DESCRIPTION
使之以nobody账户自动创建log目录
设置重启时间间隔为5秒，避免失败时无限重启循环地过于频繁